### PR TITLE
Calling style on a TableFu::Datum should not raise an exception

### DIFF
--- a/lib/table_fu.rb
+++ b/lib/table_fu.rb
@@ -365,6 +365,8 @@ class TableFu
         col_opts.index(column_name) || false
       elsif method.to_s =~ /\?$/ && !opts[method.to_s.chop.to_sym]
         nil
+      elsif method == :style
+        nil
       else
         super
       end

--- a/spec/table_fu_spec.rb
+++ b/spec/table_fu_spec.rb
@@ -58,6 +58,11 @@ describe TableFu do
     @spreadsheet.deleted_rows.length.should eql 5
     @spreadsheet.rows.length.should eql 2
   end
+
+  it 'should not require a style option' do
+    @spreadsheet.col_opts.delete :style
+    @spreadsheet.rows[0].columns[0].style.should be_nil
+  end
 end
 
 describe TableFu, 'with a complicated setup' do


### PR DESCRIPTION
```
undefined method `style' for ...:TableFu::Header
```

Unless :style is passed in the column_options hash, calling style on a TableFu::Datum raises an exception, when it should just return nil.

A consequence of the current behavior is that new users of table-setter, when defining a new table.yml, don't know why they are seeing an exception about undefined method "style" and may give up. style should not be a required option.

The test I added throws an exception unless my change to method_missing is applied.
