### PR TITLE
Method missing declaration is wrong

### DIFF
--- a/lib/table_fu/formatting.rb
+++ b/lib/table_fu/formatting.rb
@@ -38,7 +38,7 @@ class TableFu::Formatting
     end
     
     # Returns an error message if the given formatter isn't available
-    def method_missing(method)
+    def method_missing(method, *args)
       "#{method.to_s} not a valid formatter!"
     end
     


### PR DESCRIPTION
```
#<ArgumentError: wrong number of arguments (2 for 1)>
```

This is corrected by declaring method_missing as `def method_missing(method, *args)` instead of `def method_missing(method)`
