### PR TITLE
Macros should be able to return nil without raising an exception

### DIFF
--- a/lib/table_fu.rb
+++ b/lib/table_fu.rb
@@ -276,8 +276,8 @@ class TableFu
     # And finally we return a empty string object or the value.
     #
     def to_s
-      ret = if macro_value
-              macro_value
+      ret = if macro?
+              macro_value.to_s
             elsif @spreadsheet.formatting && format_method = @spreadsheet.formatting[column_name]
               TableFu::Formatting.send(format_method, @datum) || ''
             else
@@ -287,10 +287,18 @@ class TableFu
       ret
     end
 
-    # Returns the macro'd format if there is one
+    # Returns whether there is a macro format
     #
     # Returns:
-    # The macro value if it exists, otherwise nil
+    # true if there is a macro format, false or nil otherwise
+    def macro?
+      @spreadsheet.formatting && @spreadsheet.formatting[@column_name].is_a?(Hash)
+    end
+
+    # Returns the macro'd format
+    #
+    # Returns:
+    # The macro value
     def macro_value
       # Grab the macro method first
       # Then get a array of the values in the columns listed as arguments
@@ -302,14 +310,12 @@ class TableFu
       #
       # in the above case we handle the AppendedColumn in this method
 
-      if @spreadsheet.formatting && @spreadsheet.formatting[@column_name].is_a?(Hash)
-        method = @spreadsheet.formatting[@column_name]['method']
-        arguments = @spreadsheet.formatting[@column_name]['arguments'].inject([]) do |arr,arg|
-          arr << @row.column_for(arg)
-          arr
-        end
-        TableFu::Formatting.send(method, *arguments)
+      method = @spreadsheet.formatting[@column_name]['method']
+      arguments = @spreadsheet.formatting[@column_name]['arguments'].inject([]) do |arr,arg|
+        arr << @row.column_for(arg)
+        arr
       end
+      TableFu::Formatting.send(method, *arguments)
     end
 
     # Returns the raw value of a datum

--- a/spec/table_fu_spec.rb
+++ b/spec/table_fu_spec.rb
@@ -180,6 +180,10 @@ describe TableFu, 'with macro columns' do
         "#{first}#{second}"
       end
 
+      def null(first)
+        nil
+      end
+
     end
 
   end
@@ -190,7 +194,8 @@ describe TableFu, 'with macro columns' do
     @spreadsheet = TableFu.new(csv)
     @spreadsheet.col_opts[:style] = {'Projects' => 'text-align:left;'}
     @spreadsheet.col_opts[:formatting] = {'Total Appropriation' => :currency,
-                                          'MacroColumn' => {'method' => 'append', 'arguments' => ['Projects','State']}}
+                                          'MacroColumn' => {'method' => 'append', 'arguments' => ['Projects','State']},
+                                          'NullColumn' => {'method' => 'null', 'arguments' => ['Projects']}}
     @spreadsheet.sorted_by = {'Projects' => {'order' => 'descending'}}
     @spreadsheet.col_opts[:columns] = ['State', 'Total Appropriation', 'Projects', 'MacroColumn']
   end
@@ -204,6 +209,9 @@ describe TableFu, 'with macro columns' do
     @spreadsheet.rows[1].column_for('Total Appropriation').to_s.should eql '$42,367,198'
   end
 
+  it "should allow macros that take arguments to return nil" do
+    @spreadsheet.rows[0].column_for('NullColumn').to_s.should eql ''
+  end
 end
 
 describe TableFu, 'with reordered columns' do


### PR DESCRIPTION
If you define a macro that conditionally returns a string, e.g.:

```
class TableFu::Formatting
  class << self
    def link_unless(linkname, href)
      title = linkname.to_s.gsub(/(["])/, "'")
      if !href.value.nil? && !href.value.to_s().empty?
        "<a href=\"#{href}\" title=\"#{title}\">#{linkname}</a>"
      end
    end
  end
end
```

You'll get this error:

```
#<TypeError: {"method"=>"link_unless", "arguments"=>["first", "second"]} is not a symbol>
```

You need to add an `else ""` branch to avoid the exception.

A gem user doesn't necessarily know that macros must return strings and cannot return nil. The above exception is useless and frustrating to the gem user who doesn't know how to diagnose the problem This patch makes it so that macros can return nil (nil is transformed into `""`). Oh, and I added a test that fails without the patch.
