### PR TITLE
to_s should always return a string

### DIFF
--- a/lib/table_fu.rb
+++ b/lib/table_fu.rb
@@ -281,7 +281,7 @@ class TableFu
             elsif @spreadsheet.formatting && format_method = @spreadsheet.formatting[column_name]
               TableFu::Formatting.send(format_method, @datum) || ''
             else
-              @datum || ''
+              @datum.to_s || ''
             end
       ret.force_encoding("UTF-8") if RUBY_VERSION > "1.9"
       ret

--- a/spec/table_fu_spec.rb
+++ b/spec/table_fu_spec.rb
@@ -58,6 +58,10 @@ describe TableFu do
     @spreadsheet.deleted_rows.length.should eql 5
     @spreadsheet.rows.length.should eql 2
   end
+
+  it 'should convert a total to a string' do
+    @spreadsheet.total_for('Projects').to_s.should eql '24'
+  end
 end
 
 describe TableFu, 'with a complicated setup' do


### PR DESCRIPTION
If I run table-setter's example_faceted at `http://0.0.0.0:3000/example_faceted/`, I get:

```
NoMethodError: undefined method `force_encoding' for 76:Fixnum 
```

This patch calls `to_s` on `@datum` to avoid that exception.

This seems to only affect total_for calls. (The bug is with table-fu, not table-setter.)
